### PR TITLE
change dtype to object and list of col names

### DIFF
--- a/aiqc/__init__.py
+++ b/aiqc/__init__.py
@@ -942,7 +942,7 @@ class Dataset(BaseModel):
 				if type(expectedString) != 	str:
 					raise ValueError(f'\nThe input contains an object of type non-str type: {type(expectedString)}')
 
-			dataframe = pd.DataFrame(strings, columns = Dataset.Text.column_name, dtype = "string")
+			dataframe = pd.DataFrame(strings, columns = [Dataset.Text.column_name], dtype = "object")
 
 			return Dataset.Tabular.from_pandas(dataframe, name)
 


### PR DESCRIPTION
# Pull Request (PR) Template

This updates the dtype for strings to object to be backwards compatible with to_parquet() from pandas. Also fixes a bug related in the pandas constructor call

---

> *Put an `x` inside the applicable checkboxes `[ ]`.*

## Primary type of change:
- [ ] New feature.
- [x ] Bug fix.
- [ ] Refactor.
- [ ] Documentation.
- [ ] Build/ devops.
- [ ] Test.
- [ ] Other.

## Checklist:
- [ x] I have actually ran this code locally to make sure it works.
- [ x] I have pulled and merged the latest `main` into my feature branch.
- [ x] I have ran the existing [tests](https://github.com/aiqc/aiqc/new/main/.github#how-to-run-tests), and inspected areas that my code touches.
- [ ] I have updated the tests to include my changes.
- [ ] I have included updates to the documentation.
- [ ] I have built the documentation files `make html`.
- [ ] I am pushing a *branch*, not my *main/ master*.

> Describe the env you tested on: Ubuntu 20, Python 3.8

## Contains breaking changes:
- [ ] Yes (explain what functionality it breaks).
- [x ] No
