### PR TITLE
Keras models

### DIFF
--- a/aiqc/__init__.py
+++ b/aiqc/__init__.py
@@ -3468,7 +3468,7 @@ class Plot():
 		fig.update_xaxes(zeroline=False, gridcolor='#262B2F', tickfont=dict(color='#818487'))
 		fig.update_yaxes(zeroline=False, gridcolor='#262B2F', tickfont=dict(color='#818487'))
 		fig.show()
-
+		return fig
 
 	def learning_curve(self, dataframe:object, analysis_type:str, loss_skip_15pct:bool=False):
 		"""Dataframe rows are epochs and columns are metric names."""
@@ -4255,9 +4255,9 @@ class Queue(BaseModel):
 		if dataframe.empty:
 			print("Yikes - There are no models that met the criteria specified.")
 		else:
-			Plot().performance(dataframe=dataframe)
+			fig = Plot().performance(dataframe=dataframe)
 
-
+			return fig
 
 
 class Jobset(BaseModel):
@@ -4899,7 +4899,7 @@ class Job(BaseModel):
 			- Assuming `model.save()` will trigger OS-specific h5 drivers.
 			"""
 			# Write it.
-			temp_file_name = f"{app_dir}temp_keras_model"
+			temp_file_name = f"{app_dir}temp_keras_model.h5"
 			model.save(
 				temp_file_name
 				, include_optimizer = True
@@ -5046,11 +5046,13 @@ class Predictor(BaseModel):
 
 		if (algorithm.library == "keras"):
 			#https://www.tensorflow.org/guide/keras/save_and_serialize
-			temp_file_name = f"{app_dir}temp_keras_model"
+			temp_file_name = f"{app_dir}temp_keras_model.h5"
 			# Workaround: write bytes to file so keras can read from path instead of buffer.
 			with open(temp_file_name, 'wb') as f:
 				f.write(model_blob)
-				model = keras.models.load_model(temp_file_name, compile=True)
+			import h5py
+			g = h5py.File(temp_file_name, 'r')
+			model = keras.models.load_model(g, compile=True)
 			os.remove(temp_file_name)
 			# Unlike pytorch, it's doesn't look like you need to initialize the optimizer or anything.
 			return model

--- a/aiqc/__init__.py
+++ b/aiqc/__init__.py
@@ -4255,7 +4255,7 @@ class Queue(BaseModel):
 		if dataframe.empty:
 			print("Yikes - There are no models that met the criteria specified.")
 		else:
-			fig = Plot().performance(dataframe=dataframe)
+			Plot().performance(dataframe=dataframe)
 
 
 class Jobset(BaseModel):

--- a/aiqc/__init__.py
+++ b/aiqc/__init__.py
@@ -4258,6 +4258,8 @@ class Queue(BaseModel):
 			Plot().performance(dataframe=dataframe)
 
 
+
+
 class Jobset(BaseModel):
 	"""
 	- Used to group cross-fold Jobs.

--- a/aiqc/__init__.py
+++ b/aiqc/__init__.py
@@ -3468,7 +3468,7 @@ class Plot():
 		fig.update_xaxes(zeroline=False, gridcolor='#262B2F', tickfont=dict(color='#818487'))
 		fig.update_yaxes(zeroline=False, gridcolor='#262B2F', tickfont=dict(color='#818487'))
 		fig.show()
-		return fig
+
 
 	def learning_curve(self, dataframe:object, analysis_type:str, loss_skip_15pct:bool=False):
 		"""Dataframe rows are epochs and columns are metric names."""
@@ -4256,8 +4256,6 @@ class Queue(BaseModel):
 			print("Yikes - There are no models that met the criteria specified.")
 		else:
 			fig = Plot().performance(dataframe=dataframe)
-
-			return fig
 
 
 class Jobset(BaseModel):


### PR DESCRIPTION
Basic fix to clarify the saving of keras models.

---

## Does this solve an existing [Issue](https://github.com/aiqc/aiqc/issues)? 
- If so, please link to the issue.
- If not, please describe *what* your change does and *why*.

Running the basic examples, I see issues with the keras handling of the model saving (I think due to the lack of specificity of the h5py File handler)

  File "/home/mcoughlin/anaconda3/envs/aiqc/lib/python3.8/site-packages/tensorflow/python/saved_model/loader_impl.py", line 111, in parse_saved_model
    raise IOError("SavedModel file does not exist at: %s/{%s|%s}" %
OSError: SavedModel file does not exist at: /home/michael.coughlin/.local/share/aiqc/temp_keras_model/{saved_model.pbtxt|saved_model.pb}

---

> *Put an `x` inside the applicable checkboxes `[ ]`.*

## Primary type of change:
- [ ] New feature.
- [x] Bug fix.
- [ ] Refactor.
- [ ] Documentation.
- [ ] Build/ devops.
- [ ] Test.
- [ ] Other.

## Checklist:
- [x] I have actually ran this code locally to make sure it works.
- [ ] I have pulled and merged the latest `main` into my feature branch.
- [ ] I have ran the existing [tests](https://github.com/aiqc/aiqc/new/main/.github#how-to-run-tests), and inspected areas that my code touches.
- [ ] I have updated the tests to include my changes.
- [ ] I have included updates to the documentation.
- [ ] I have built the documentation files `make html`.

> Describe the env you tested on: OS, Python version, shell type (e.g. cli, ide, notebook).
Linux, 3.8, python script

## Contains breaking changes:
- [ ] Yes (explain what functionality it breaks).
- [x] No

---

## How to run the tests.
The source code for tests is located in `aiqc/aiqc/tests/__init__.py`. 

Once we are confident that our schema handles all data types and analysis types, we will invest more rigorous testing.
```python
import aiqc
from aiqc import tests

q1 = tests.make_test_queue('keras_binary')
q1.run_jobs()

q2 = tests.make_test_queue('keras_multiclass')
q2.run_jobs()

q3 = tests.make_test_queue('keras_regression')
q3.run_jobs()

q4 = tests.make_test_queue('keras_image_binary')
q4.run.jobs()

q5 = tests.make_test_queue('pytorch_binary')
q5.run.jobs()

q6 = tests.make_test_queue('pytorch_multiclass')
q6.run.jobs()

q7 = tests.make_test_queue('pytorch_regression')
q7.run.jobs()

q8 = tests.make_test_queue('pytorch_image_binary')
q8.run.jobs()
```

I ran with success tests 1-3 which I could imagine this touches. Does test 4 work generally?

>>> q4.run.jobs()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Queue' object has no attribute 'run'
